### PR TITLE
Do not create quick link if target is empty

### DIFF
--- a/Assets/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Assets/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -801,6 +801,9 @@ namespace SimpleFileBrowser
 
 		private void AddQuickLink( Sprite icon, string name, string path, ref Vector2 anchoredPos )
 		{
+			if (!Directory.Exists(path))
+				return;
+			
 			FileBrowserQuickLink quickLink = Instantiate( quickLinkPrefab, quickLinksContainer, false );
 			quickLink.SetFileBrowser( this );
 


### PR DESCRIPTION
using this in my own game and this is one of the tweaks I found useful enough for everyone

it may be a good idea to add a toggle for this feature, though