### PR TITLE
Check file case insensitive filenames depending on file system

### DIFF
--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -2468,8 +2468,13 @@ namespace SimpleFileBrowser
 		{
 			for( int i = 0; i < validFileEntries.Count; i++ )
 			{
-				if( validFileEntries[i].Name.Length == length && input.IndexOf( validFileEntries[i].Name, startIndex, length ) == startIndex )
-					return i;
+				bool bFileExists;
+				if (IsCaseSensitiveFileSystem(m_currentPath))
+					bFileExists = validFileEntries[i].Name.Length == length && input.IndexOf(validFileEntries[i].Name, startIndex, length, StringComparison.Ordinal) == startIndex; 
+				else
+					bFileExists = string.Equals(validFileEntries[i].Name, input, StringComparison.CurrentCultureIgnoreCase);
+				
+				if (bFileExists) return i;
 			}
 
 			return -1;
@@ -2786,6 +2791,11 @@ namespace SimpleFileBrowser
 			}
 
 			return false;
+		}
+
+		private static bool IsCaseSensitiveFileSystem(string path)
+		{
+			return !Directory.Exists(path.ToUpper()) || !Directory.Exists(path.ToLower());
 		}
 
 		public static Permission CheckPermission()


### PR DESCRIPTION
When you set a default file name, that doesn't match the case of a file in the selected directory, it will not match. This update does a quick check to see if the file system is case insensitive and then does a case insensitive check against it. 