### PR TITLE
Add reference to Unity.InputSystem assembly.

### DIFF
--- a/Plugins/SimpleFileBrowser/SimpleFileBrowser.Runtime.asmdef
+++ b/Plugins/SimpleFileBrowser/SimpleFileBrowser.Runtime.asmdef
@@ -1,3 +1,6 @@
-﻿{
-	"name": "SimpleFileBrowser.Runtime"
+{
+    "name": "SimpleFileBrowser.Runtime",
+    "references": [
+        "GUID:75469ad4d38634e559750d17036d5f7c"
+    ]
 }


### PR DESCRIPTION
Fixes compiler errors when using the new input system.