### PR TITLE
Use conventional modifier key for macOS/iOS: Command instead of Control; Change Shift modifier behaviour.

### DIFF
--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -788,6 +788,24 @@ namespace SimpleFileBrowser
 			get { return PlayerPrefs.GetString( "FBLastPath", null ); }
 			set { PlayerPrefs.SetString( "FBLastPath", value ); }
 		}
+
+		// If Command Key on Apple Devices OR Ctrl/Control key on others is pressed.
+		private bool IsCtrlKeyHeld()
+		{
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+			return Keyboard.current != null && (Keyboard.current.leftCommandKey.isPressed || Keyboard.current.rightCommandKey.isPressed);
+#else
+			return Keyboard.current != null && Keyboard.current.ctrlKey.isPressed;
+#endif
+#else // not (ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER)
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+			return Input.GetKey(KeyCode.LeftCommand) || Input.GetKey(KeyCode.RightCommand);
+#else
+            return Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+#endif
+#endif
+		}
 		#endregion
 
 		#region Delegates
@@ -940,21 +958,9 @@ namespace SimpleFileBrowser
 						RenameSelectedFile();
 
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-					if( Keyboard.current[Key.A].wasPressedThisFrame &&
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
-							(Keyboard.current.leftCommandKey.isPressed || Keyboard.current.rightCommandKey.isPressed)
+					if( Keyboard.current[Key.A].wasPressedThisFrame && IsCtrlKeyHeld())
 #else
-							Keyboard.current.ctrlKey.isPressed
-#endif
-					)
-#else
-					if( Input.GetKeyDown( KeyCode.A ) &&
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
-						Input.GetKey( KeyCode.LeftCommand )
-#else
-						Input.GetKey( KeyCode.LeftControl )
-#endif
-					)
+					if( Input.GetKeyDown( KeyCode.A ) && IsCtrlKeyHeld())
 #endif
 						SelectAllFiles();
 				}
@@ -1799,21 +1805,7 @@ namespace SimpleFileBrowser
 
 						// When in toggle selection mode or Control key (Command on macOS) is held, individual items can be multi-selected
 #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WEBGL || UNITY_WSA || UNITY_WSA_10_0
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-						if( m_multiSelectionToggleSelectionMode || ( Keyboard.current != null &&
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
-							(Keyboard.current.leftCommandKey.isPressed || Keyboard.current.rightCommandKey.isPressed)
-#else
-							Keyboard.current.ctrlKey.isPressed
-#endif
-						) )
-#else
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
-						if( m_multiSelectionToggleSelectionMode || Input.GetKey( KeyCode.LeftCommand ) || Input.GetKey( KeyCode.RightCommand ) )
-#else
-						if( m_multiSelectionToggleSelectionMode || Input.GetKey( KeyCode.LeftControl ) || Input.GetKey( KeyCode.RightControl ) )
-#endif
-#endif
+						if( m_multiSelectionToggleSelectionMode || IsCtrlKeyHeld() )
 #else
 						if( m_multiSelectionToggleSelectionMode )
 #endif

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -940,9 +940,15 @@ namespace SimpleFileBrowser
 						RenameSelectedFile();
 
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-					if( Keyboard.current[Key.A].wasPressedThisFrame && Keyboard.current.ctrlKey.isPressed )
+					if( Keyboard.current[Key.A].wasPressedThisFrame && Keyboard.current.actionKey.isPressed )
 #else
-					if( Input.GetKeyDown( KeyCode.A ) && ( Input.GetKey( KeyCode.LeftControl ) || Input.GetKey( KeyCode.LeftCommand ) ) )
+					if( Input.GetKeyDown( KeyCode.A ) &&
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+						Input.GetKey( KeyCode.LeftCommand )
+#else
+						Input.GetKey( KeyCode.LeftControl )
+#endif
+					)
 #endif
 						SelectAllFiles();
 				}
@@ -1783,12 +1789,16 @@ namespace SimpleFileBrowser
 					{
 						multiSelectionPivotFileEntry = item.Position;
 
-						// When in toggle selection mode or Control key is held, individual items can be multi-selected
+						// When in toggle selection mode or Control key (Command on macOS, thus actionKey) is held, individual items can be multi-selected
 #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WEBGL || UNITY_WSA || UNITY_WSA_10_0
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-						if( m_multiSelectionToggleSelectionMode || ( Keyboard.current != null && Keyboard.current.ctrlKey.isPressed ) )
+						if( m_multiSelectionToggleSelectionMode || ( Keyboard.current != null && Keyboard.current.actionKey.isPressed ) )
+#else
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+						if( m_multiSelectionToggleSelectionMode || Input.GetKey( KeyCode.LeftCommand ) || Input.GetKey( KeyCode.RightCommand ) )
 #else
 						if( m_multiSelectionToggleSelectionMode || Input.GetKey( KeyCode.LeftControl ) || Input.GetKey( KeyCode.RightControl ) )
+#endif
 #endif
 #else
 						if( m_multiSelectionToggleSelectionMode )

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -940,7 +940,13 @@ namespace SimpleFileBrowser
 						RenameSelectedFile();
 
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-					if( Keyboard.current[Key.A].wasPressedThisFrame && Keyboard.current.actionKey.isPressed )
+					if( Keyboard.current[Key.A].wasPressedThisFrame &&
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+							(Keyboard.current.leftCommandKey.isPressed || Keyboard.current.rightCommandKey.isPressed)
+#else
+							Keyboard.current.ctrlKey.isPressed
+#endif
+					)
 #else
 					if( Input.GetKeyDown( KeyCode.A ) &&
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
@@ -1789,10 +1795,16 @@ namespace SimpleFileBrowser
 					{
 						multiSelectionPivotFileEntry = item.Position;
 
-						// When in toggle selection mode or Control key (Command on macOS, thus actionKey) is held, individual items can be multi-selected
+						// When in toggle selection mode or Control key (Command on macOS) is held, individual items can be multi-selected
 #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WEBGL || UNITY_WSA || UNITY_WSA_10_0
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-						if( m_multiSelectionToggleSelectionMode || ( Keyboard.current != null && Keyboard.current.actionKey.isPressed ) )
+						if( m_multiSelectionToggleSelectionMode || ( Keyboard.current != null &&
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
+							(Keyboard.current.leftCommandKey.isPressed || Keyboard.current.rightCommandKey.isPressed)
+#else
+							Keyboard.current.ctrlKey.isPressed
+#endif
+						) )
 #else
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
 						if( m_multiSelectionToggleSelectionMode || Input.GetKey( KeyCode.LeftCommand ) || Input.GetKey( KeyCode.RightCommand ) )

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -1,4 +1,4 @@
-﻿//#define WIN_DIR_CHECK_WITHOUT_TIMEOUT // When uncommented, Directory.Exists won't be wrapped inside a Task/Thread on Windows but we won't be able to set a timeout for unreachable directories/drives
+//#define WIN_DIR_CHECK_WITHOUT_TIMEOUT // When uncommented, Directory.Exists won't be wrapped inside a Task/Thread on Windows but we won't be able to set a timeout for unreachable directories/drives
 
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -1771,12 +1771,11 @@ namespace SimpleFileBrowser
 						multiSelectionPivotFileEntry = Mathf.Clamp( multiSelectionPivotFileEntry, 0, validFileEntries.Count - 1 );
 
 						selectedFileEntries.Clear();
-						selectedFileEntries.Add( item.Position );
 
-						for( int i = multiSelectionPivotFileEntry; i < item.Position; i++ )
+						for( int i = multiSelectionPivotFileEntry; i <= item.Position; i++ )
 							selectedFileEntries.Add( i );
 
-						for( int i = multiSelectionPivotFileEntry; i > item.Position; i-- )
+						for( int i = multiSelectionPivotFileEntry; i >= item.Position; i-- )
 							selectedFileEntries.Add( i );
 					}
 					else

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -1784,11 +1784,13 @@ namespace SimpleFileBrowser
 
 						selectedFileEntries.Clear();
 
-						for( int i = multiSelectionPivotFileEntry; i <= item.Position; i++ )
+						for( int i = multiSelectionPivotFileEntry; i < item.Position; i++ )
 							selectedFileEntries.Add( i );
 
-						for( int i = multiSelectionPivotFileEntry; i >= item.Position; i-- )
+						for( int i = multiSelectionPivotFileEntry; i > item.Position; i-- )
 							selectedFileEntries.Add( i );
+
+						selectedFileEntries.Add( item.Position );
 					}
 					else
 #endif

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -788,24 +788,6 @@ namespace SimpleFileBrowser
 			get { return PlayerPrefs.GetString( "FBLastPath", null ); }
 			set { PlayerPrefs.SetString( "FBLastPath", value ); }
 		}
-
-		// If Command Key on Apple Devices OR Ctrl/Control key on others is pressed.
-		private bool IsCtrlKeyHeld()
-		{
-#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
-			return Keyboard.current != null && (Keyboard.current.leftCommandKey.isPressed || Keyboard.current.rightCommandKey.isPressed);
-#else
-			return Keyboard.current != null && Keyboard.current.ctrlKey.isPressed;
-#endif
-#else // not (ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER)
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS
-			return Input.GetKey(KeyCode.LeftCommand) || Input.GetKey(KeyCode.RightCommand);
-#else
-            return Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
-#endif
-#endif
-		}
 		#endregion
 
 		#region Delegates
@@ -958,9 +940,9 @@ namespace SimpleFileBrowser
 						RenameSelectedFile();
 
 #if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
-					if( Keyboard.current[Key.A].wasPressedThisFrame && IsCtrlKeyHeld())
+					if( Keyboard.current[Key.A].wasPressedThisFrame && IsCtrlKeyHeld() )
 #else
-					if( Input.GetKeyDown( KeyCode.A ) && IsCtrlKeyHeld())
+					if( Input.GetKeyDown( KeyCode.A ) && IsCtrlKeyHeld() )
 #endif
 						SelectAllFiles();
 				}
@@ -1803,7 +1785,7 @@ namespace SimpleFileBrowser
 					{
 						multiSelectionPivotFileEntry = item.Position;
 
-						// When in toggle selection mode or Control key (Command on macOS) is held, individual items can be multi-selected
+						// When in toggle selection mode or Control/Command key is held, individual items can be multi-selected
 #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WEBGL || UNITY_WSA || UNITY_WSA_10_0
 						if( m_multiSelectionToggleSelectionMode || IsCtrlKeyHeld() )
 #else
@@ -2179,7 +2161,7 @@ namespace SimpleFileBrowser
 				// Don't select folders in file picking mode if MultiSelectionToggleSelectionMode is enabled or about to be enabled
 				for( int i = 0; i < validFileEntries.Count; i++ )
 				{
-#if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WSA || UNITY_WSA_10_0
+#if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WEBGL || UNITY_WSA || UNITY_WSA_10_0
 					if( !m_multiSelectionToggleSelectionMode || !validFileEntries[i].IsDirectory )
 #else
 					if( !validFileEntries[i].IsDirectory )
@@ -2848,6 +2830,24 @@ namespace SimpleFileBrowser
 				}
 				catch { }
 			}
+		}
+
+		// Check if Control/Command key is held
+		private bool IsCtrlKeyHeld()
+		{
+#if ENABLE_INPUT_SYSTEM && !ENABLE_LEGACY_INPUT_MANAGER
+#if UNITY_EDITOR_OSX || ( !UNITY_EDITOR && UNITY_STANDALONE_OSX )
+			return Keyboard.current != null && ( Keyboard.current.leftCommandKey.isPressed || Keyboard.current.rightCommandKey.isPressed );
+#else
+			return Keyboard.current != null && Keyboard.current.ctrlKey.isPressed;
+#endif
+#else
+#if UNITY_EDITOR_OSX || ( !UNITY_EDITOR && UNITY_STANDALONE_OSX )
+			return Input.GetKey( KeyCode.LeftCommand ) || Input.GetKey( KeyCode.RightCommand );
+#else
+			return Input.GetKey( KeyCode.LeftControl ) || Input.GetKey( KeyCode.RightControl );
+#endif
+#endif
 		}
 		#endregion
 


### PR DESCRIPTION
1. 781d76a changes the shift key behaviour: it selects all items from previous selected to current, thus all items are selected in sequence. Previously, the current selected items is added to the selected paths list first.
2. 73c7106 uses command key on macOS/iOS for multiple selection or select all, which is more conventional.