### PR TITLE
Fix platform dependent compilation for OSX

### DIFF
--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -1070,7 +1070,7 @@ namespace SimpleFileBrowser
 				AddQuickLink( m_skin.DriveIcon, "Files", Application.persistentDataPath );
 #endif
 
-#if UNITY_STANDALONE_OSX
+#if UNITY_EDITOR_OSX || ( !UNITY_EDITOR && UNITY_STANDALONE_OSX )
 				// Add a quick link for user directory on Mac OS
 				string userDirectory = Environment.GetFolderPath( Environment.SpecialFolder.MyDocuments );
 				if( !string.IsNullOrEmpty( userDirectory ) )
@@ -1083,7 +1083,7 @@ namespace SimpleFileBrowser
 			{
 				QuickLink quickLink = quickLinks[i];
 				string quickLinkPath = Environment.GetFolderPath( quickLink.target );
-#if UNITY_STANDALONE_OSX
+#if UNITY_EDITOR_OSX || ( !UNITY_EDITOR && UNITY_STANDALONE_OSX )
 				// Documents folder must be appended manually on Mac OS
 				if( quickLink.target == Environment.SpecialFolder.MyDocuments && !string.IsNullOrEmpty( quickLinkPath ) )
 					quickLinkPath = Path.Combine( quickLinkPath, "Documents" );
@@ -1198,7 +1198,7 @@ namespace SimpleFileBrowser
 				if( string.IsNullOrEmpty( drives[i] ) )
 					continue;
 
-#if UNITY_STANDALONE_OSX
+#if UNITY_EDITOR_OSX || ( !UNITY_EDITOR && UNITY_STANDALONE_OSX )
 				// There are a number of useless drives listed on Mac OS, filter them
 				if( drives[i] == "/" )
 				{


### PR DESCRIPTION
There are code blocks wrapped by `UNITY_STANDALONE_OSX` to only work on OSX.
But to make them also work in the Unity Editor on macOS, a check for `UNITY_EDITOR_OSX` needs to be added as well.

## 1. Filter quick link section from too many macOS drives

### Before
![image](https://github.com/yasirkula/UnitySimpleFileBrowser/assets/17184113/c43b4f50-ba51-44e5-921d-3ccc9b2023c1)

### After
![image](https://github.com/yasirkula/UnitySimpleFileBrowser/assets/17184113/08c71790-d28e-4a44-8ca9-ac42e8481a25)

## 2. Documents quick link should lead into actual `~/Documents` folder

### Before
![image](https://github.com/yasirkula/UnitySimpleFileBrowser/assets/17184113/a033d802-9143-4247-9e14-6edb70e6cbe1)

### After
![image](https://github.com/yasirkula/UnitySimpleFileBrowser/assets/17184113/af726667-f20c-4a74-a213-3f615af04f1e)

## 3. Add user folder to quick link section
![image](https://github.com/yasirkula/UnitySimpleFileBrowser/assets/17184113/11529e21-a0c6-4bac-83f1-879b61f4a9d0)

