### PR TITLE
fix: Unhandled IOException in DeleteSelectedFiles crashing the app

### DIFF
--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -2343,11 +2343,18 @@ namespace SimpleFileBrowser
 			{
 				for( int i = selectedFileEntries.Count - 1; i >= 0; i-- )
 				{
-					FileSystemEntry fileInfo = validFileEntries[selectedFileEntries[i]];
-					if( fileInfo.IsDirectory )
-						FileBrowserHelpers.DeleteDirectory( fileInfo.Path );
-					else
-						FileBrowserHelpers.DeleteFile( fileInfo.Path );
+					try
+					{
+						FileSystemEntry fileInfo = validFileEntries[selectedFileEntries[i]];
+						if( fileInfo.IsDirectory )
+							FileBrowserHelpers.DeleteDirectory( fileInfo.Path );
+						else
+							FileBrowserHelpers.DeleteFile( fileInfo.Path );
+					}
+					catch( System.IO.IOException e )
+					{
+						Debug.LogWarning( "Could not delete file: " + e.Message );
+					}
 				}
 
 				selectedFileEntries.Clear();

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -2353,7 +2353,7 @@ namespace SimpleFileBrowser
 					}
 					catch( IOException e )
 					{
-						Debug.LogWarning( "Could not delete file: " + e.Message );
+						Debug.LogError( $"Could not delete '{fileInfo.Path}': " + e.Message );
 					}
 				}
 

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -2351,7 +2351,7 @@ namespace SimpleFileBrowser
 						else
 							FileBrowserHelpers.DeleteFile( fileInfo.Path );
 					}
-					catch( System.IO.IOException e )
+					catch( IOException e )
 					{
 						Debug.LogWarning( "Could not delete file: " + e.Message );
 					}

--- a/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Plugins/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -2353,7 +2353,7 @@ namespace SimpleFileBrowser
 					}
 					catch( IOException e )
 					{
-						Debug.LogError( $"Could not delete '{fileInfo.Path}': " + e.Message );
+						Debug.LogError( $"Could not delete '{fileInfo.Path}': {e.Message}" );
 					}
 				}
 


### PR DESCRIPTION
Fixes a crash when trying to delete files that are locked by another process (e.g. OneDrive sync, antivirus). Previously, an unhandled IOException would kill the app. Now the deletion loop catches the exception, logs a warning, and keeps going so the rest of the selected files still get deleted and the file list refreshes properly.